### PR TITLE
Add simple web quiz interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ python rbi_quiz.py
 
 This prints a JSON array of ten questions that can be consumed by a
 front-end or another service.
+
+### Web Interface
+
+A minimal Flask app serves a simple Wordle-style UI for the quiz.
+
+```
+python app.py
+```
+
+Visit `http://localhost:8000` in your browser to play. After
+answering all ten questions you can copy a shareable emoji score that
+links back to the site.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,19 @@
+from flask import Flask, jsonify, send_from_directory
+from rbi_quiz import generate_quiz
+
+app = Flask(__name__, static_folder='static', static_url_path='')
+
+
+@app.route('/quiz')
+def quiz():
+    questions = [q.__dict__ for q in generate_quiz()]
+    return jsonify(questions)
+
+
+@app.route('/')
+def index():
+    return send_from_directory(app.static_folder, 'index.html')
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+flask

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>RBI Quiz</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="game">
+    <h1>RBI Quiz</h1>
+    <div id="question-container" class="hidden">
+      <div id="question"></div>
+      <div id="options"></div>
+    </div>
+    <div id="result" class="hidden"></div>
+    <button id="share" class="hidden">Share</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,58 @@
+let questions = [];
+let current = 0;
+let results = [];
+
+const questionContainer = document.getElementById('question-container');
+const questionEl = document.getElementById('question');
+const optionsEl = document.getElementById('options');
+const resultEl = document.getElementById('result');
+const shareBtn = document.getElementById('share');
+
+fetch('/quiz')
+  .then(res => res.json())
+  .then(data => {
+    questions = data;
+    showQuestion();
+  });
+
+function showQuestion() {
+  const q = questions[current];
+  questionEl.textContent = q.question;
+  optionsEl.innerHTML = '';
+  q.options.forEach((opt, idx) => {
+    const btn = document.createElement('button');
+    btn.textContent = opt;
+    btn.addEventListener('click', () => handleAnswer(btn, idx === q.correct_index));
+    optionsEl.appendChild(btn);
+  });
+  questionContainer.classList.remove('hidden');
+}
+
+function handleAnswer(btn, correct) {
+  Array.from(optionsEl.children).forEach(b => b.disabled = true);
+  btn.classList.add(correct ? 'correct' : 'wrong');
+  results.push(correct);
+  setTimeout(() => {
+    current++;
+    if (current < questions.length) {
+      showQuestion();
+    } else {
+      showResult();
+    }
+  }, 800);
+}
+
+function showResult() {
+  questionContainer.classList.add('hidden');
+  const score = results.filter(Boolean).length;
+  const emoji = results.map(r => (r ? '🟩' : '🟥')).join('');
+  resultEl.textContent = `Score: ${score}/${results.length}\n${emoji}`;
+  resultEl.classList.remove('hidden');
+  shareBtn.classList.remove('hidden');
+  shareBtn.onclick = () => {
+    const shareText = `RBI Quiz ${score}/${results.length}\n${emoji}\n${window.location.href}`;
+    navigator.clipboard.writeText(shareText);
+    shareBtn.textContent = 'Copied!';
+    setTimeout(() => (shareBtn.textContent = 'Share'), 2000);
+  };
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,34 @@
+body {
+  font-family: sans-serif;
+  text-align: center;
+  background: #f5f5f5;
+}
+#game {
+  margin: 0 auto;
+  max-width: 600px;
+  padding: 20px;
+}
+button {
+  cursor: pointer;
+  padding: 10px 20px;
+  margin: 5px;
+  border: none;
+  border-radius: 4px;
+  background: #e0e0e0;
+  transition: background 0.3s ease;
+}
+button.correct {
+  background: #6aaa64;
+  color: #fff;
+}
+button.wrong {
+  background: #c23b22;
+  color: #fff;
+}
+.hidden {
+  display: none;
+}
+#result {
+  font-size: 1.2em;
+  margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- Serve RBI quiz through a lightweight Flask app.
- Implement a minimal Wordle-style front-end with answer feedback and sharable emoji score.
- Document how to run the web interface and add Flask dependency.

## Testing
- `python -m py_compile rbi_quiz.py app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09a541ff0832e926ff11fa8e0bfaf