### PR TITLE
Refactor quiz to load RBI questions and improve selection feedback

### DIFF
--- a/rbi_questions.json
+++ b/rbi_questions.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "RBI1",
+    "question": "What does the Cash Reserve Ratio (CRR) require banks to do?",
+    "options": [
+      "Maintain a portion of deposits with RBI",
+      "Keep cash in ATMs",
+      "Invest in foreign bonds",
+      "Provide loans to NBFCs"
+    ],
+    "correct_index": 0,
+    "difficulty": "Easy"
+  },
+  {
+    "id": "RBI2",
+    "question": "Which facility allows banks to park excess funds with RBI without collateral?",
+    "options": [
+      "Standing Deposit Facility",
+      "Marginal Standing Facility",
+      "Repo Facility",
+      "Open Market Operations"
+    ],
+    "correct_index": 0,
+    "difficulty": "Medium"
+  },
+  {
+    "id": "RBI3",
+    "question": "What is the purpose of the Statutory Liquidity Ratio (SLR)?",
+    "options": [
+      "Ensure banks maintain liquid assets",
+      "Control foreign exchange",
+      "Set interest rates",
+      "Provide deposit insurance"
+    ],
+    "correct_index": 0,
+    "difficulty": "Easy"
+  },
+  {
+    "id": "RBI4",
+    "question": "In Open Market Operations, which securities does RBI primarily trade?",
+    "options": [
+      "Government securities",
+      "Corporate bonds",
+      "Equities",
+      "Municipal bonds"
+    ],
+    "correct_index": 0,
+    "difficulty": "Medium"
+  },
+  {
+    "id": "RBI5",
+    "question": "Which committee's recommendations led to the introduction of NEFT?",
+    "options": [
+      "Saraf Committee",
+      "Narasimham Committee",
+      "Tarapore Committee",
+      "Kelkar Committee"
+    ],
+    "correct_index": 0,
+    "difficulty": "Medium"
+  },
+  {
+    "id": "RBI6",
+    "question": "What is the main objective of the Prompt Corrective Action (PCA) framework?",
+    "options": [
+      "Maintain the soundness of banks",
+      "Regulate stock exchanges",
+      "Control inflation",
+      "Manage foreign trade"
+    ],
+    "correct_index": 0,
+    "difficulty": "Medium"
+  },
+  {
+    "id": "RBI7",
+    "question": "Which Act empowers RBI to regulate Non-Banking Financial Companies (NBFCs)?",
+    "options": [
+      "RBI Act 1934",
+      "Banking Regulation Act 1949",
+      "Companies Act 2013",
+      "SARFAESI Act 2002"
+    ],
+    "correct_index": 0,
+    "difficulty": "Hard"
+  },
+  {
+    "id": "RBI8",
+    "question": "Which facility provides overnight liquidity to banks against government securities?",
+    "options": [
+      "Marginal Standing Facility",
+      "Standing Deposit Facility",
+      "Repo Facility",
+      "Cash Reserve Ratio"
+    ],
+    "correct_index": 0,
+    "difficulty": "Medium"
+  },
+  {
+    "id": "RBI9",
+    "question": "What does LAF stand for in RBI’s monetary policy toolkit?",
+    "options": [
+      "Liquidity Adjustment Facility",
+      "Loan Administration Fund",
+      "Long-term Assistance Framework",
+      "Liquidity Allocation Fund"
+    ],
+    "correct_index": 0,
+    "difficulty": "Easy"
+  },
+  {
+    "id": "RBI10",
+    "question": "Under the RBI guidelines, what is the purpose of priority sector lending?",
+    "options": [
+      "Ensure credit flow to vital sectors like agriculture",
+      "Finance luxury real estate",
+      "Support speculative trading",
+      "Increase banks' profits"
+    ],
+    "correct_index": 0,
+    "difficulty": "Easy"
+  }
+]

--- a/rbi_quiz.py
+++ b/rbi_quiz.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import random
 from dataclasses import dataclass, asdict
+from pathlib import Path
 from typing import List
 
 
@@ -14,52 +15,15 @@ class Question:
     difficulty: str
 
 
-def generate_question_bank(num_questions: int = 5000) -> List[Question]:
-    """Generate a diversified bank of arithmetic questions.
+def load_question_bank(path: str = "rbi_questions.json") -> List[Question]:
+    """Load pre-generated RBI quiz questions from a JSON file."""
 
-    The random seed is initialised with today's date so a new set of questions
-    is produced each day while remaining deterministic for that day.
-    """
-
-    random.seed(datetime.date.today().isoformat())
-    bank: List[Question] = []
-    difficulties = ["Easy", "Medium", "Hard"]
-    operations = ["+", "-", "*", "/"]
-
-    for i in range(1, num_questions + 1):
-        op = random.choice(operations)
-        a = random.randint(1, 100)
-        b = random.randint(1, 100)
-        if op == "/":
-            # ensure divisible numbers for integer results
-            a = a * b
-        expression = f"{a} {op} {b}"
-        correct = eval(expression)
-
-        # create 3 unique incorrect options
-        options = [correct]
-        while len(options) < 4:
-            delta = random.randint(-10, 10)
-            option = correct + delta
-            if option not in options:
-                options.append(option)
-        random.shuffle(options)
-
-        difficulty = random.choice(difficulties)
-        bank.append(
-            Question(
-                id=f"Q{i}",
-                question=f"What is {expression}?",
-                options=[str(o) for o in options],
-                correct_index=options.index(correct),
-                difficulty=difficulty,
-            )
-        )
-
-    return bank
+    with open(Path(path), "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return [Question(**q) for q in data]
 
 
-QUESTIONS: List[Question] = generate_question_bank()
+QUESTIONS: List[Question] = load_question_bank()
 
 
 def generate_quiz(num_questions: int = 10) -> List[Question]:

--- a/static/script.js
+++ b/static/script.js
@@ -33,7 +33,7 @@ function showQuestion() {
     const btn = document.createElement('button');
     btn.textContent = opt;
     btn.className = 'option';
-    btn.onclick = () => selectAnswer(idx);
+    btn.addEventListener('click', () => selectAnswer(idx, btn));
     optionsEl.appendChild(btn);
   });
   nextBtn.classList.add('hidden');
@@ -41,10 +41,11 @@ function showQuestion() {
   feedbackEl.textContent = '';
 }
 
-function selectAnswer(idx) {
+function selectAnswer(idx, clickedBtn) {
   const q = questions[current];
   Array.from(optionsEl.children).forEach((btn, bIdx) => {
     btn.disabled = true;
+    if (btn === clickedBtn) btn.classList.add('selected');
     if (bIdx === q.correct_index) btn.classList.add('correct');
     if (bIdx === idx && bIdx !== q.correct_index) btn.classList.add('wrong');
   });

--- a/static/style.css
+++ b/static/style.css
@@ -72,6 +72,11 @@ body {
   border-color: #e0e0e0;
 }
 
+button.selected {
+  background: #e3f2fd;
+  border-color: #1976d2;
+}
+
 button.correct {
   background: #2e7d32;
   color: #fff;


### PR DESCRIPTION
## Summary
- Load quiz data from a JSON file of RBI circular questions instead of generating random math
- Highlight selected answers for clearer response feedback
- Add initial RBI question bank

## Testing
- `python -m py_compile app.py rbi_quiz.py`
- `python rbi_quiz.py | head`


------
https://chatgpt.com/codex/tasks/task_e_68a0cd333e5c832e8420e5cc67c39194